### PR TITLE
Allow custom mappings

### DIFF
--- a/plugin/smoothie.vim
+++ b/plugin/smoothie.vim
@@ -4,12 +4,12 @@ nnoremap <silent> <Plug>(SmoothieForwards)  :<C-U>call smoothie#forwards()  <CR>
 nnoremap <silent> <Plug>(SmoothieBackwards) :<C-U>call smoothie#backwards() <CR>
 
 if get(g:, 'smoothie_use_default_mappings', v:true)
-  silent! map <unique> <C-D>      <Plug>(SmoothieDownwards)
-  silent! map <unique> <C-U>      <Plug>(SmoothieUpwards)
-  silent! map <unique> <C-F>      <Plug>(SmoothieForwards)
-  silent! map <unique> <S-Down>   <Plug>(SmoothieForwards)
-  silent! map <unique> <PageDown> <Plug>(SmoothieForwards)
-  silent! map <unique> <C-B>      <Plug>(SmoothieBackwards)
-  silent! map <unique> <S-Up>     <Plug>(SmoothieBackwards)
-  silent! map <unique> <PageUp>   <Plug>(SmoothieBackwards)
+  silent! nmap <unique> <C-D>      <Plug>(SmoothieDownwards)
+  silent! nmap <unique> <C-U>      <Plug>(SmoothieUpwards)
+  silent! nmap <unique> <C-F>      <Plug>(SmoothieForwards)
+  silent! nmap <unique> <S-Down>   <Plug>(SmoothieForwards)
+  silent! nmap <unique> <PageDown> <Plug>(SmoothieForwards)
+  silent! nmap <unique> <C-B>      <Plug>(SmoothieBackwards)
+  silent! nmap <unique> <S-Up>     <Plug>(SmoothieBackwards)
+  silent! nmap <unique> <PageUp>   <Plug>(SmoothieBackwards)
 en

--- a/plugin/smoothie.vim
+++ b/plugin/smoothie.vim
@@ -1,8 +1,15 @@
-nnoremap <silent> <C-D>      :<C-U>call smoothie#downwards() <CR>
-nnoremap <silent> <C-U>      :<C-U>call smoothie#upwards()   <CR>
-nnoremap <silent> <C-F>      :<C-U>call smoothie#forwards()  <CR>
-nnoremap <silent> <S-Down>   :<C-U>call smoothie#forwards()  <CR>
-nnoremap <silent> <PageDown> :<C-U>call smoothie#forwards()  <CR>
-nnoremap <silent> <C-B>      :<C-U>call smoothie#backwards() <CR>
-nnoremap <silent> <S-Up>     :<C-U>call smoothie#backwards() <CR>
-nnoremap <silent> <PageUp>   :<C-U>call smoothie#backwards() <CR>
+nnoremap <silent> <Plug>(SmoothieDownwards) :<C-U>call smoothie#downwards() <CR>
+nnoremap <silent> <Plug>(SmoothieUpwards)   :<C-U>call smoothie#upwards()   <CR>
+nnoremap <silent> <Plug>(SmoothieForwards)  :<C-U>call smoothie#forwards()  <CR>
+nnoremap <silent> <Plug>(SmoothieBackwards) :<C-U>call smoothie#backwards() <CR>
+
+if get(g:, 'smoothie_use_default_mappings', v:true)
+  silent! map <unique> <C-D>      <Plug>(SmoothieDownwards)
+  silent! map <unique> <C-U>      <Plug>(SmoothieUpwards)
+  silent! map <unique> <C-F>      <Plug>(SmoothieForwards)
+  silent! map <unique> <S-Down>   <Plug>(SmoothieForwards)
+  silent! map <unique> <PageDown> <Plug>(SmoothieForwards)
+  silent! map <unique> <C-B>      <Plug>(SmoothieBackwards)
+  silent! map <unique> <S-Up>     <Plug>(SmoothieBackwards)
+  silent! map <unique> <PageUp>   <Plug>(SmoothieBackwards)
+en


### PR DESCRIPTION
This makes it possible to disable the default mappings, for example:
```vim
let g:smoothie_use_default_mappings = v:false

nmap <C-j> <Plug>(SmoothieDownwards)
nmap <C-k> <Plug>(SmoothieUpwards)
```
Also, the commit adds so that existing mappings will not be overwritten by the plugin.