### PR TITLE
Add command to enable and disable smoothie

### DIFF
--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -199,3 +199,29 @@ endfunction
 function smoothie#backwards()
   call s:update_target(-winheight(0) * v:count1)
 endfunction
+
+""
+" Enable smoothie
+function smoothie#enable()
+  nnoremap <silent> <C-D>      :<C-U>call smoothie#downwards() <CR>
+  nnoremap <silent> <C-U>      :<C-U>call smoothie#upwards()   <CR>
+  nnoremap <silent> <C-F>      :<C-U>call smoothie#forwards()  <CR>
+  nnoremap <silent> <S-Down>   :<C-U>call smoothie#forwards()  <CR>
+  nnoremap <silent> <PageDown> :<C-U>call smoothie#forwards()  <CR>
+  nnoremap <silent> <C-B>      :<C-U>call smoothie#backwards() <CR>
+  nnoremap <silent> <S-Up>     :<C-U>call smoothie#backwards() <CR>
+  nnoremap <silent> <PageUp>   :<C-U>call smoothie#backwards() <CR>
+endfunction
+
+""
+" Disable smoothie
+function smoothie#disable()
+  unmap <C-D>
+  unmap <C-U>
+  unmap <C-F>
+  unmap <S-Down>
+  unmap <PageDown>
+  unmap <C-B>
+  unmap <S-Up>
+  unmap <PageUp>
+endfunction

--- a/plugin/smoothie.vim
+++ b/plugin/smoothie.vim
@@ -1,8 +1,4 @@
-nnoremap <silent> <C-D>      :<C-U>call smoothie#downwards() <CR>
-nnoremap <silent> <C-U>      :<C-U>call smoothie#upwards()   <CR>
-nnoremap <silent> <C-F>      :<C-U>call smoothie#forwards()  <CR>
-nnoremap <silent> <S-Down>   :<C-U>call smoothie#forwards()  <CR>
-nnoremap <silent> <PageDown> :<C-U>call smoothie#forwards()  <CR>
-nnoremap <silent> <C-B>      :<C-U>call smoothie#backwards() <CR>
-nnoremap <silent> <S-Up>     :<C-U>call smoothie#backwards() <CR>
-nnoremap <silent> <PageUp>   :<C-U>call smoothie#backwards() <CR>
+call smoothie#enable()
+
+command SmoothieEnable :call smoothie#enable()
+command SmoothieDisable :call smoothie#disable()


### PR DESCRIPTION
In some situations, such as the terminal is getting slow, we may want to disable smoothie.

So I added `SmoothieEnable` and `SmoothieDisable` command to enable and disable smoothie quickly.