### PR TITLE
improve ^F and ^B by handling 'window' and 'wrap' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ replaces. That is, every command should still behave exactly as described in
 which hopefully will be addressed in the future:
 
 * `^D`, `^U`, `^F`, `^B` should beep when they can't move any further.
-* `^F` and `^B` should respect the `window` option.
 * Native commands may move in a smarter way over wrapped/folded lines.
 
 

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -175,6 +175,20 @@ function s:count_to_scroll()
 endfunction
 
 ""
+" Helper function to figure out how many lines ^F and ^B should scroll,
+" taking the 'window' option into account like the native commands do
+function s:get_window_height()
+  " get number of lines visible on screen, even if 'wrap' option is set
+  let l:lines_to_scroll = line('w$') - line('w0') - 1
+
+  if winnr('$') == 1 && &window < &lines - 1
+    let l:lines_to_scroll = max([&window - 2, 1])
+  endif
+
+  return l:lines_to_scroll
+endfunction
+
+""
 " Smooth equivalent to ^D.
 function smoothie#downwards()
   call s:count_to_scroll()
@@ -191,11 +205,13 @@ endfunction
 ""
 " Smooth equivalent to ^F.
 function smoothie#forwards()
-  call s:update_target(winheight(0) * v:count1)
+  let l:winheight = s:get_window_height()
+  call s:update_target(l:winheight * v:count1)
 endfunction
 
 ""
 " Smooth equivalent to ^B.
 function smoothie#backwards()
-  call s:update_target(-winheight(0) * v:count1)
+  let l:winheight = s:get_window_height()
+  call s:update_target(-l:winheight * v:count1)
 endfunction

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -175,11 +175,9 @@ function s:count_to_scroll()
 endfunction
 
 ""
-" Helper function to figure out how many lines ^F and ^B should scroll,
-" taking the 'window' option into account like the native commands do
+" Helper function to figure out how many lines ^F and ^B should scroll, taking
+" the 'window' and 'wrap' options into account like the native commands do
 function s:get_window_height()
-  " get number of lines visible on screen, even if 'wrap' option is set and
-  " there are folds visible
   let l:lines_to_scroll = winheight(0) - 2
 
   if &wrap
@@ -188,8 +186,8 @@ function s:get_window_height()
     let l:lines_unwrapped = line('w$') - line('w0') - 1
     setl wrap
 
-    let l:number_of_visible_wrapping_lines = l:lines_unwrapped - l:lines_wrapped
-    let l:lines_to_scroll -= l:number_of_visible_wrapping_lines
+    let l:number_of_lines_on_screen_that_wrap = l:lines_unwrapped - l:lines_wrapped
+    let l:lines_to_scroll -= l:number_of_lines_on_screen_that_wrap
   endif
 
   if winnr('$') == 1 && &window < &lines - 1

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -183,11 +183,10 @@ function s:get_window_height()
   let l:lines_to_scroll = winheight(0) - 2
 
   if &wrap
-    let l:wrapsave = &wrap
     let l:lines_wrapped = line('w$') - line('w0') - 1
     setl nowrap
     let l:lines_unwrapped = line('w$') - line('w0') - 1
-    let &wrap = l:wrapsave
+    setl wrap
 
     let l:number_of_visible_wrapping_lines = l:lines_unwrapped - l:lines_wrapped
     let l:lines_to_scroll -= l:number_of_visible_wrapping_lines

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -178,8 +178,20 @@ endfunction
 " Helper function to figure out how many lines ^F and ^B should scroll,
 " taking the 'window' option into account like the native commands do
 function s:get_window_height()
-  " get number of lines visible on screen, even if 'wrap' option is set
-  let l:lines_to_scroll = line('w$') - line('w0') - 1
+  " get number of lines visible on screen, even if 'wrap' option is set and
+  " there are folds visible
+  let l:lines_to_scroll = winheight(0) - 2
+
+  if &wrap
+    let l:wrapsave = &wrap
+    let l:lines_wrapped = line('w$') - line('w0') - 1
+    setl nowrap
+    let l:lines_unwrapped = line('w$') - line('w0') - 1
+    let &wrap = l:wrapsave
+
+    let l:number_of_visible_wrapping_lines = l:lines_unwrapped - l:lines_wrapped
+    let l:lines_to_scroll -= l:number_of_visible_wrapping_lines
+  endif
 
   if winnr('$') == 1 && &window < &lines - 1
     let l:lines_to_scroll = max([&window - 2, 1])

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -180,7 +180,10 @@ endfunction
 function s:get_window_height()
   let l:lines_to_scroll = winheight(0) - 2
 
-  if &wrap
+  if winnr('$') == 1 && &window < &lines - 1 " from :h 'window'
+    let l:lines_to_scroll = max([&window - 2, 1])
+
+  elseif &wrap
     let l:lines_wrapped = line('w$') - line('w0') - 1
     setl nowrap
     let l:lines_unwrapped = line('w$') - line('w0') - 1
@@ -188,10 +191,6 @@ function s:get_window_height()
 
     let l:number_of_lines_on_screen_that_wrap = l:lines_unwrapped - l:lines_wrapped
     let l:lines_to_scroll -= l:number_of_lines_on_screen_that_wrap
-  endif
-
-  if winnr('$') == 1 && &window < &lines - 1
-    let l:lines_to_scroll = max([&window - 2, 1])
   endif
 
   return l:lines_to_scroll


### PR DESCRIPTION
Take 'window' option into account when determining how many lines to scroll for ^F and ^B, using the logic described in `:help 'window'`                                                                                                    

Also fix a small bug where ^F and ^B would not scroll the correct number of lines if the 'wrap' option was set and there were wrapped lines visible on the screen

This leaves one small issue unaddressed: in default vim, if you give ^F or ^B a count, and there are wrapped lines in the file, vim will effectively do ^F or ^B multiple times, scrolling a number of lines equal to the number of lines visible after each iteration - 1. This is significant because with 'wrap' set, the number of lines visible at each point in the file might be different, so in default vim, 3^F might not scroll exactly (3 * (line('w$') - line('w0') - 1)) lines like smoothie#backwards() and smoothie#forwards would.