### PR TITLE
Feature/zt zz zb

### DIFF
--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -335,8 +335,19 @@ endfunction
 
 ""
 " Helper function to get line number at bottom of the window
+" Takes into account folds
 function s:winbottomline()
-  return s:wintopline() + winheight(0) - 1
+  let l:bottomline = s:wintopline()
+  let l:i = 1
+  while i < winheight(0)
+    if foldclosed(l:bottomline) != -1
+      let l:bottomline += foldclosedend(l:bottomline) - foldclosed(l:bottomline)
+    endif
+
+    let l:bottomline += 1
+    let l:i += 1
+  endwhile
+  return l:bottomline
 endfunction
 
 ""
@@ -412,12 +423,11 @@ endfunction
 
 function smoothie#bottom()
   let s:lines = s:calculate_screen_lines(s:winbottomline() - &scrolloff, line('.'))
-  echom 'Bottom line: '.(s:winbottomline() - &scrolloff)
-  " call s:perform_disjoint_scroll(s:lines)
+  call s:perform_disjoint_scroll(s:lines)
 endfunction
 
 function smoothie#fold(from, to)
-  return s:calculate_screen_lines(a:from, a:to)
+  return s:winbottomline()
 endfunction
 
 ""

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -364,6 +364,8 @@ endfunction
 
 ""
 " Helper function to perform a disjoint scroll
+" where the screen moves separatly from the 
+" cursor
 function s:perform_disjoint_scroll(lines)
   let s:disjoint_scroll = v:true
   let s:ctrl_f_invoked = v:false
@@ -422,25 +424,38 @@ function smoothie#backwards()
   call s:update_target(-winheight(0) * v:count1)
 endfunction
 
-
-function smoothie#middle()
-  echom s:winmidline()
-  let s:lines = s:calculate_screen_lines(s:winmidline(), line('.'))
-  call s:perform_disjoint_scroll(s:lines)
-endfunction
-
+""
+" Smooth equivalent to zt
 function smoothie#top()
-  let s:lines = s:calculate_screen_lines(s:wintopline() + &scrolloff, line('.'))
-  call s:perform_disjoint_scroll(s:lines)
+  if !g:smoothie_enabled
+    exe "normal! zt"
+    return
+  endif
+  let l:lines = s:calculate_screen_lines(s:wintopline() + &scrolloff, line('.'))
+  call s:perform_disjoint_scroll(l:lines)
 endfunction
 
+""
+" Smooth equivalent to zz or z.
+function smoothie#middle()
+  if !g:smoothie_enabled
+    exe "normal! zz"
+    return
+  endif
+  echom s:winmidline()
+  let l:lines = s:calculate_screen_lines(s:winmidline(), line('.'))
+  call s:perform_disjoint_scroll(l:lines)
+endfunction
+
+""
+" Smooth equivalent to zb
 function smoothie#bottom()
-  let s:lines = s:calculate_screen_lines(s:winbottomline() - &scrolloff, line('.'))
-  call s:perform_disjoint_scroll(s:lines)
-endfunction
-
-function smoothie#fold(from, to)
-  return s:winbottomline()
+  if !g:smoothie_enabled
+    exe "normal! zb"
+    return
+  endif
+  let l:lines = s:calculate_screen_lines(s:winbottomline() - &scrolloff, line('.'))
+  call s:perform_disjoint_scroll(l:lines)
 endfunction
 
 ""

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -340,6 +340,20 @@ function s:winbottomline()
 endfunction
 
 ""
+" Helper function to perform a disjoint scroll
+function s:perform_disjoint_scroll(lines)
+  let s:disjoint_scroll = v:true
+  let s:ctrl_f_invoked = v:false
+  call s:update_target(a:lines)
+
+  " Wait until movement has stopped
+  while s:target_displacement != 0
+    exe 'sleep ' . g:smoothie_update_interval . ' m'
+  endwhile
+  let s:disjoint_scroll = v:false
+endfunction
+
+""
 " Smooth equivalent to ^D.
 function smoothie#downwards()
   if !g:smoothie_enabled
@@ -387,25 +401,19 @@ endfunction
 
 
 function smoothie#middle()
-  let s:midline = (winheight(0) - 1)/2 + s:wintopline()
-  call s:disjoint_update_target(line('.') - s:midline)
+  " let s:midline = (winheight(0) - 1)/2 + s:wintopline()
+  " call s:disjoint_update_target(line('.') - s:midline)
 endfunction
 
 function smoothie#top()
-  call s:disjoint_update_target(line('.') - s:wintopline() - &scrolloff)
+  " call s:disjoint_update_target(line('.') - s:wintopline() - &scrolloff)
 endfunction
 
 function smoothie#bottom()
-  let s:lines = line('.') - s:winbottomline() - &scrolloff
-
-  let s:disjoint_scroll = v:true
-  let s:ctrl_f_invoked = v:false
-  call s:update_target(s:lines)
-  while !((winbottomline() - &scrolloff) == line('.') || s:wintopline() == 1)
-    exe 'sleep ' . g:smoothie_update_interval . ' m'
-  endwhile
-  let s:disjoint_scroll = v:false
+  let s:lines = s:calculate_screen_lines(s:winbottomline() - &scrolloff, line('.'))
+  call s:perform_disjoint_scroll(s:lines)
 endfunction
+
 
 ""
 " Smoothie equivalent for G and gg

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -276,11 +276,6 @@ function s:update_target(lines)
 endfunction
 
 ""
-" Call update_target but execute a disjoint_scroll
-function s:disjoint_update_target(lines)
-endfunction
-
-""
 " Helper function to calculate the actual number of screen lines from a line
 " to another.  Useful for properly handling folds in case of cursor movements.
 function s:calculate_screen_lines(from, to)
@@ -331,6 +326,23 @@ endfunction
 " Helper function to get line number at top of the window
 function s:wintopline()
   return winsaveview()['topline']
+endfunction
+
+""
+" Helper function to get line number at the middle of the window
+" Takes into account folds
+function s:winmidline()
+  let l:midline = s:wintopline()
+  let l:i = 0
+  while i < (winheight(0) - 1)/2
+    if foldclosed(l:midline) != -1
+      let l:midline += foldclosedend(l:midline) - foldclosed(l:midline)
+    endif
+
+    let l:midline += 1
+    let l:i += 1
+  endwhile
+  return l:midline
 endfunction
 
 ""
@@ -412,8 +424,9 @@ endfunction
 
 
 function smoothie#middle()
-  " let s:midline = (winheight(0) - 1)/2 + s:wintopline()
-  " call s:disjoint_update_target(line('.') - s:midline)
+  echom s:winmidline()
+  let s:lines = s:calculate_screen_lines(s:winmidline(), line('.'))
+  call s:perform_disjoint_scroll(s:lines)
 endfunction
 
 function smoothie#top()

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -406,14 +406,19 @@ function smoothie#middle()
 endfunction
 
 function smoothie#top()
-  " call s:disjoint_update_target(line('.') - s:wintopline() - &scrolloff)
+  let s:lines = s:calculate_screen_lines(s:wintopline() + &scrolloff, line('.'))
+  call s:perform_disjoint_scroll(s:lines)
 endfunction
 
 function smoothie#bottom()
   let s:lines = s:calculate_screen_lines(s:winbottomline() - &scrolloff, line('.'))
-  call s:perform_disjoint_scroll(s:lines)
+  echom 'Bottom line: '.(s:winbottomline() - &scrolloff)
+  " call s:perform_disjoint_scroll(s:lines)
 endfunction
 
+function smoothie#fold(from, to)
+  return s:calculate_screen_lines(a:from, a:to)
+endfunction
 
 ""
 " Smoothie equivalent for G and gg

--- a/plugin/smoothie.vim
+++ b/plugin/smoothie.vim
@@ -26,13 +26,13 @@ if has('nvim') || has('patch-8.2.1978')
     silent! map <unique> <C-B>      <Plug>(SmoothieBackwards)
     silent! map <unique> <S-Up>     <Plug>(SmoothieBackwards)
     silent! map <unique> <PageUp>   <Plug>(SmoothieBackwards)
-    silent! map <unique> zt         <Plug>(SmoothieTop)
-    silent! map <unique> zz         <Plug>(SmoothieMiddle)
-    silent! map <unique> z.         <Plug>(SmoothieMiddle)
-    silent! map <unique> zb         <Plug>(SmoothieBottom)
     if get(g:, 'smoothie_experimental_mappings', v:false)
       silent! map <unique> gg         <Plug>(Smoothie_gg)
       silent! map <unique> G          <Plug>(Smoothie_G)
+      silent! map <unique> zt         <Plug>(SmoothieTop)
+      silent! map <unique> zz         <Plug>(SmoothieMiddle)
+      silent! map <unique> z.         <Plug>(SmoothieMiddle)
+      silent! map <unique> zb         <Plug>(SmoothieBottom)
     endif
   endif
 else
@@ -55,13 +55,13 @@ else
     silent! nmap <unique> <C-B>      <Plug>(SmoothieBackwards)
     silent! nmap <unique> <S-Up>     <Plug>(SmoothieBackwards)
     silent! nmap <unique> <PageUp>   <Plug>(SmoothieBackwards)
-    silent! map <unique> zt          <Plug>(SmoothieTop)
-    silent! map <unique> zz          <Plug>(SmoothieMiddle)
-    silent! map <unique> z.          <Plug>(SmoothieMiddle)
-    silent! map <unique> zb          <Plug>(SmoothieBottom)
     if get(g:, 'smoothie_experimental_mappings', v:false)
       silent! nmap <unique> gg         <Plug>(Smoothie_gg)
       silent! nmap <unique> G          <Plug>(Smoothie_G)
+      silent! map <unique> zt          <Plug>(SmoothieTop)
+      silent! map <unique> zz          <Plug>(SmoothieMiddle)
+      silent! map <unique> z.          <Plug>(SmoothieMiddle)
+      silent! map <unique> zb          <Plug>(SmoothieBottom)
     endif
   endif
 endif

--- a/plugin/smoothie.vim
+++ b/plugin/smoothie.vim
@@ -13,6 +13,9 @@ if has('nvim') || has('patch-8.2.1978')
   noremap <silent> <Plug>(SmoothieBackwards) <cmd>call smoothie#backwards()           <CR>
   noremap <silent> <Plug>(Smoothie_gg)       <cmd>call smoothie#cursor_movement('gg') <CR>
   noremap <silent> <Plug>(Smoothie_G)        <cmd>call smoothie#cursor_movement('G')  <CR>
+  noremap <silent> <Plug>(SmoothieTop)       <cmd>call smoothie#top()                 <CR>
+  noremap <silent> <Plug>(SmoothieMiddle)    <cmd>call smoothie#middle()              <CR>
+  noremap <silent> <Plug>(SmoothieBottom)    <cmd>call smoothie#bottom()              <CR>
 
   if !get(g:, 'smoothie_no_default_mappings', v:false)
     silent! map <unique> <C-D>      <Plug>(SmoothieDownwards)
@@ -23,6 +26,10 @@ if has('nvim') || has('patch-8.2.1978')
     silent! map <unique> <C-B>      <Plug>(SmoothieBackwards)
     silent! map <unique> <S-Up>     <Plug>(SmoothieBackwards)
     silent! map <unique> <PageUp>   <Plug>(SmoothieBackwards)
+    silent! map <unique> zt         <Plug>(SmoothieTop)
+    silent! map <unique> zz         <Plug>(SmoothieMiddle)
+    silent! map <unique> z.         <Plug>(SmoothieMiddle)
+    silent! map <unique> zb         <Plug>(SmoothieBottom)
     if get(g:, 'smoothie_experimental_mappings', v:false)
       silent! map <unique> gg         <Plug>(Smoothie_gg)
       silent! map <unique> G          <Plug>(Smoothie_G)
@@ -35,6 +42,9 @@ else
   nnoremap <silent> <Plug>(SmoothieBackwards) :<C-U>call smoothie#backwards()           <CR>
   nnoremap <silent> <Plug>(Smoothie_gg)       :<C-U>call smoothie#cursor_movement('gg') <CR>
   nnoremap <silent> <Plug>(Smoothie_G)        :<C-U>call smoothie#cursor_movement('G')  <CR>
+  nnoremap <silent> <Plug>(SmoothieTop)        :<C-U>call smoothie#top()                 <CR>
+  nnoremap <silent> <Plug>(SmoothieMiddle)     :<C-U>call smoothie#middle()              <CR>
+  nnoremap <silent> <Plug>(SmoothieBottom)     :<C-U>call smoothie#bottom()              <CR>
 
   if !get(g:, 'smoothie_no_default_mappings', v:false)
     silent! nmap <unique> <C-D>      <Plug>(SmoothieDownwards)
@@ -45,6 +55,10 @@ else
     silent! nmap <unique> <C-B>      <Plug>(SmoothieBackwards)
     silent! nmap <unique> <S-Up>     <Plug>(SmoothieBackwards)
     silent! nmap <unique> <PageUp>   <Plug>(SmoothieBackwards)
+    silent! map <unique> zt          <Plug>(SmoothieTop)
+    silent! map <unique> zz          <Plug>(SmoothieMiddle)
+    silent! map <unique> z.          <Plug>(SmoothieMiddle)
+    silent! map <unique> zb          <Plug>(SmoothieBottom)
     if get(g:, 'smoothie_experimental_mappings', v:false)
       silent! nmap <unique> gg         <Plug>(Smoothie_gg)
       silent! nmap <unique> G          <Plug>(Smoothie_G)


### PR DESCRIPTION
### What?
This is a pull request that transforms the zt zz z. zb commands to smoothie commands. It takes into account folds and scrolloff.

### Why?
These changes will decrease cognitive load for users using the zt zz z. zb commands as it's easier to follow.

### How?
- Coined the term disjoint scrolls to describe scrolling that is separate from the cursor (let me know if you want a different name)
- Changed the step_down and step_up functions to perform disjoint scrolls.
- Added functions smoothie#top, smoothie#bottom, smoothie#middle for zt, zb, zz commands respectively
- These mappings will go into experimental mappings.