### PR TITLE
Add support for n N # * g* g#

### DIFF
--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -181,18 +181,29 @@ function s:update_target(command)
   if !empty(s:target_view)
     call winrestview(s:target_view)
   endif
-  execute 'normal! ' . v:count1 . a:command
+  if v:count == 0
+    execute 'normal! ' . a:command
+  else
+    execute 'normal! ' . v:count . a:command
+  endif
   let s:target_view = winsaveview()
   call winrestview(l:current_view)
+  return [v:hlsearch, @/, v:searchforward]
 endfunction
 
 function smoothie#do(command)
   if g:smoothie_enabled
-    call s:update_target(a:command)
+    let l:search = s:update_target(a:command)
     call s:start_moving()
   else
-    execute 'normal! ' . v:count1 . a:command
+    if v:count == 0
+      execute 'normal! ' . a:command
+    else
+      execute 'normal! ' . v:count . a:command
+    endif
+    let l:search = [v:hlsearch, @/, v:searchforward]
   endif
+  return l:search
 endfunction
 
 ""

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -185,28 +185,27 @@ function s:update_target(command)
   if !empty(s:target_view)
     call winrestview(s:target_view)
   endif
-  if v:count == 0
-    execute 'normal! ' . a:command
-  else
-    execute 'normal! ' . v:count . a:command
-  endif
+  execute 'normal! ' . (v:count ? v:count : '') . a:command
   let s:target_view = winsaveview()
   call winrestview(l:current_view)
   return [v:hlsearch, @/, v:searchforward]
 endfunction
 
 function smoothie#do(command)
-  if g:smoothie_enabled
-    let l:search = s:update_target(a:command)
-    call s:start_moving()
-  else
-    if v:count == 0
-      execute 'normal! ' . a:command
+  let l:search = [v:hlsearch, @/, v:searchforward]
+  try
+    if g:smoothie_enabled
+      let l:search = s:update_target(a:command)
+      call s:start_moving()
     else
-      execute 'normal! ' . v:count . a:command
+      execute 'normal! ' . (v:count ? v:count : '') . a:command
+      let l:search = [v:hlsearch, @/, v:searchforward]
     endif
-    let l:search = [v:hlsearch, @/, v:searchforward]
-  endif
+  catch
+      echoh ErrorMsg
+      echom substitute(v:exception, '^[^:]*:', '', '')
+      echoh None
+  endtry
   return l:search
 endfunction
 

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -181,7 +181,7 @@ function s:update_target(command)
   if !empty(s:target_view)
     call winrestview(s:target_view)
   endif
-  execute 'normal! ' . v:count . a:command
+  execute 'normal! ' . v:count1 . a:command
   let s:target_view = winsaveview()
   call winrestview(l:current_view)
 endfunction
@@ -191,7 +191,7 @@ function smoothie#do(command)
     call s:update_target(a:command)
     call s:start_moving()
   else
-    execute 'normal! ' . v:count . a:command
+    execute 'normal! ' . v:count1 . a:command
   endif
 endfunction
 

--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -1,3 +1,7 @@
+
+let smoothie#default_commands = ['<C-D>', '<C-U>', '<C-F>', '<S-Down>', '<PageDown>', '<C-B>', '<S-Up>', '<PageUp>', 'z+', 'z^', 'zt', 'z<CR>', 'z.', 'zz', 'z-', 'zb']
+let smoothie#experimental_commands = ['gg', 'G']
+
 function s:editor_supports_fast_redraw()
   " Currently enabled only for Neovim, because it causes screen flickering on
   " regular Vim.

--- a/plugin/smoothie.vim
+++ b/plugin/smoothie.vim
@@ -48,7 +48,7 @@ if !exists('g:smoothie_remapped_commands')
   if !g:smoothie_no_default_mappings
     let g:smoothie_remapped_commands = ['<C-D>', '<C-U>', '<C-F>', '<S-Down>', '<PageDown>', '<C-B>', '<S-Up>', '<PageUp>', 'z+', 'z^', 'zt', 'z<CR>', 'z.', 'zz', 'z-', 'zb']
     if g:smoothie_experimental_mappings
-      let g:smoothie_remapped_commands += ['gg', 'G']
+      let g:smoothie_remapped_commands += ['gg', 'G', 'n', 'N', '#', '*', 'g*', 'g#']
     endif
   else
     let g:smoothie_remapped_commands = []
@@ -58,8 +58,9 @@ endif
 ""
 " Add mappings to override commands which should be smoothened
 for remapped_command in g:smoothie_remapped_commands
+  let s:hlsearch = ''
   for mapping_command in ['nnoremap', 'vnoremap']
-    execute 'silent! ' . mapping_command . ' <unique> ' . remapped_command . ' <cmd>call smoothie#do("' . substitute(remapped_command, '<', '\\<lt>', '') . '") <CR>'
+    execute 'silent! ' . mapping_command . ' <unique> ' . remapped_command . ' <cmd>let [v:hlsearch, @/, v:searchforward]=smoothie#do("' . substitute(remapped_command, '<', '\\<lt>', '') . '")<CR>'
   endfor
 endfor
 

--- a/plugin/smoothie.vim
+++ b/plugin/smoothie.vim
@@ -46,9 +46,9 @@ if !exists('g:smoothie_remapped_commands')
   ""
   " List of commands which smoothened alternatives will be mapped for
   if !g:smoothie_no_default_mappings
-    let g:smoothie_remapped_commands = ['<C-D>', '<C-U>', '<C-F>', '<S-Down>', '<PageDown>', '<C-B>', '<S-Up>', '<PageUp>', 'z+', 'z^', 'zt', 'z<CR>', 'z.', 'zz', 'z-', 'zb']
+    let g:smoothie_remapped_commands = smoothie#default_commands
     if g:smoothie_experimental_mappings
-      let g:smoothie_remapped_commands += ['gg', 'G']
+      let g:smoothie_remapped_commands += smoothie#experimental_commands
     endif
   else
     let g:smoothie_remapped_commands = []


### PR DESCRIPTION
if no count is given `v:count` is `0`, which moves the cursor, making commands like `n` get stuck and `N` skip over matches on the same line.

`v:count1` exists, but interferes with `<C-D>` and friends.

Also, because of `:help function-search-undo`, ` n` won't re-highlight matches unless the relevant values are explicitly returned from the function and re-set.

