### PR TITLE
extract command list to autoload

### DIFF
--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -1,3 +1,7 @@
+
+let smoothie#default_commands = ['<C-D>', '<C-U>', '<C-F>', '<S-Down>', '<PageDown>', '<C-B>', '<S-Up>', '<PageUp>', 'z+', 'z^', 'zt', 'z<CR>', 'z.', 'zz', 'z-', 'zb']
+let smoothie#experimental_commands = ['gg', 'G']
+
 function s:editor_supports_fast_redraw()
   " Currently enabled only for Neovim, because it causes screen flickering on
   " regular Vim.

--- a/plugin/smoothie.vim
+++ b/plugin/smoothie.vim
@@ -46,9 +46,9 @@ if !exists('g:smoothie_remapped_commands')
   ""
   " List of commands which smoothened alternatives will be mapped for
   if !g:smoothie_no_default_mappings
-    let g:smoothie_remapped_commands = ['<C-D>', '<C-U>', '<C-F>', '<S-Down>', '<PageDown>', '<C-B>', '<S-Up>', '<PageUp>', 'z+', 'z^', 'zt', 'z<CR>', 'z.', 'zz', 'z-', 'zb']
+    let g:smoothie_remapped_commands = smoothie#default_commands
     if g:smoothie_experimental_mappings
-      let g:smoothie_remapped_commands += ['gg', 'G']
+      let g:smoothie_remapped_commands += smoothie#experimental_commands
     endif
   else
     let g:smoothie_remapped_commands = []


### PR DESCRIPTION
Doing this lets people use something like the following in their vimrc:
```
let g:smoothie_remapped_commands = smoothie#default_commands + smoothie#experimental_commands + [ '{', '}' ]
```
rather than copying the list of commands in full. This change shouldn't affect anyone with existing configurations.

For parity, the other g:vars could  be changed from `smoothie_*` to `smoothie#*`, but as it says in the note those aren't really intended to be *public*.

Also, cheers! It's a cool project